### PR TITLE
feat: focusOnDenominator option, geq and leq operators

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -13,6 +13,7 @@ The configuration options object is of the following form:
   autoCommands: 'pi theta sqrt sum',
   autoOperatorNames: 'sin cos',
   maxDepth: 10,
+  focusOnDenominator: false,
   substituteTextarea: function() {
     return document.createElement('textarea');
   },
@@ -87,6 +88,10 @@ Just like [`autoCommands`](#autocommands) above, this takes a string formatted a
 `maxDepth` specifies the maximum number of nested MathBlocks. When `maxDepth` is set to 1, the user can type simple math symbols directly into the editor but not into nested MathBlocks, e.g. the numerator and denominator of a fraction.
 
 Nested content in latex rendered during initialization or pasted into mathquill is truncated to avoid violating `maxDepth`. When `maxDepth` is not set, no depth limit is applied by default.
+
+##focusOnDenominator
+
+If `focusOnDenominator` is true then cursor put to denominator in the fraction expression. Default value is `false`.
 
 ## substituteTextarea
 

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -89,7 +89,7 @@ Just like [`autoCommands`](#autocommands) above, this takes a string formatted a
 
 Nested content in latex rendered during initialization or pasted into mathquill is truncated to avoid violating `maxDepth`. When `maxDepth` is not set, no depth limit is applied by default.
 
-##focusOnDenominator
+## focusOnDenominator
 
 If `focusOnDenominator` is true then cursor put to denominator in the fraction expression. Default value is `false`.
 

--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -134,9 +134,9 @@ var MathCommand = P(MathElement, function(_, super_) {
   _.placeCursor = function(cursor) {
     //insert the cursor at the right end of the first empty child, searching
     //left-to-right, or if none empty, the right end child
-    cursor.insAtRightEnd(this.foldChildren(this.ends[L], function(leftward, child) {
-      return leftward.isEmpty() ? leftward : child;
-    }));
+    cursor.insAtRightEnd(this.foldChildren(this.ends[cursor.options.focusOnDenominator ? R : L]
+      , function (leftward, child) { return leftward.isEmpty() ? leftward : child; }
+    ));
   };
 
   // editability methods: called by the cursor for editing, cursor movements,

--- a/src/commands/math/basicSymbols.js
+++ b/src/commands/math/basicSymbols.js
@@ -499,11 +499,17 @@ var less = { ctrlSeq: '\\le ', html: '&le;', text: '≤',
              ctrlSeqStrict: '<', htmlStrict: '&lt;', textStrict: '<' };
 var greater = { ctrlSeq: '\\ge ', html: '&ge;', text: '≥',
                 ctrlSeqStrict: '>', htmlStrict: '&gt;', textStrict: '>' };
+var geq = { ctrlSeq: '\\geq ', html: '\u2267', text: '\u2267',
+            ctrlSeqStrict: '>', htmlStrict: '\u2267', textStrict: '>' };
+var leq = { ctrlSeq: '\\leq ', html: '\u2266', text: '\u2266',
+            ctrlSeqStrict: '<', htmlStrict: '\u2266', textStrict: '<' };
 
 LatexCmds['<'] = LatexCmds.lt = bind(Inequality, less, true);
 LatexCmds['>'] = LatexCmds.gt = bind(Inequality, greater, true);
-LatexCmds['≤'] = LatexCmds.le = LatexCmds.leq = bind(Inequality, less, false);
-LatexCmds['≥'] = LatexCmds.ge = LatexCmds.geq = bind(Inequality, greater, false);
+LatexCmds['≤'] = LatexCmds.le = bind(Inequality, less, false);
+LatexCmds['≥'] = LatexCmds.ge = bind(Inequality, greater, false);
+LatexCmds.leq = bind(Inequality, leq, false);
+LatexCmds.geq = bind(Inequality, geq, false);
 
 var Equality = P(BinaryOperator, function(_, super_) {
   _.init = function() {


### PR DESCRIPTION
Features: 
 - Add a new option `focusOnDenominator` so the focus is set on fraction denominator instead of numerator
 - bind the `leq` and `geq` commands