### PR TITLE
fix: issue with iPad and Japanese keyboard

### DIFF
--- a/src/services/saneKeyboardEvents.util.js
+++ b/src/services/saneKeyboardEvents.util.js
@@ -85,12 +85,25 @@ var saneKeyboardEvents = (function() {
     modifiers.push(key);
     return modifiers.join('-');
   }
-
+  function isVisibleKey(evt) {
+    var which = evt.which || evt.keyCode;
+    var keyVal = KEY_VALUES[which];
+    return !(evt.ctrlKey || evt.originalEvent && evt.originalEvent.metaKey || evt.altKey || evt.shiftKey || keyVal);
+  }
+  function isIpadOS() {
+    return navigator.maxTouchPoints &&
+      navigator.maxTouchPoints > 2 &&
+      /MacIntel/.test(navigator.platform);
+  }
   // create a keyboard events shim that calls callbacks at useful times
   // and exports useful public methods
   return function saneKeyboardEvents(el, handlers) {
     var keydown = null;
     var keypress = null;
+    var keyup = null;
+    var input = null;
+    var textWasInserted = false;
+    var is_iPad = isIpadOS();
 
     var textarea = jQuery(el);
     var target = jQuery(handlers.container || textarea);
@@ -116,8 +129,6 @@ var saneKeyboardEvents = (function() {
         checker(e);
       });
     }
-    target.bind('keydown keypress input keyup focusout paste', function(e) { checkTextarea(e); });
-
 
     // -*- public methods -*- //
     function select(text) {
@@ -156,6 +167,9 @@ var saneKeyboardEvents = (function() {
 
       keydown = e;
       keypress = null;
+      input = null;
+      keyup = null;
+      textWasInserted = false;
 
       if (shouldBeSelected) checkTextareaOnce(function(e) {
         if (!(e && e.type === 'focusout') && textarea[0].select) {
@@ -186,8 +200,10 @@ var saneKeyboardEvents = (function() {
 
       // Handle case of no keypress event being sent
       if (!!keydown && !keypress) checkTextareaFor(typedText);
+      keyup = e;
+      checkTextareaFor(typedText);
     }
-    function typedText() {
+    function typedText(e) {
       // If there is a selection, the contents of the textarea couldn't
       // possibly have just been typed in.
       // This happens in browsers like Firefox and Opera that fire
@@ -211,6 +227,14 @@ var saneKeyboardEvents = (function() {
       if (text.length === 1) {
         textarea.val('');
         handlers.typedText(text);
+        textWasInserted = true;
+      } else if (text.length === 0 && is_iPad && !input && keydown && keyup && !textWasInserted && isVisibleKey(keydown)) {
+        // issue with iPad and Japanese keyboard
+        // only first symbol put in textare, 
+        // rest ignored and no text in textarea, no input event
+        // will be used keydown.key
+        handlers.typedText(keydown.key);
+        textWasInserted = true;
       } // in Firefox, keys that don't type text, just clear seln, fire keypress
       // https://github.com/mathquill/mathquill/issues/293#issuecomment-40997668
       else if (text && textarea[0].select) textarea[0].select(); // re-select if that's why we're here
@@ -254,6 +278,10 @@ var saneKeyboardEvents = (function() {
       cut: function() { checkTextareaOnce(function() { handlers.cut(); }); },
       copy: function() { checkTextareaOnce(function() { handlers.copy(); }); },
       paste: onPaste
+    });
+    // -*- attach event handlers -*- //
+    textarea.bind({
+      input: function(e) { input = e; },
     });
 
     // -*- export public methods -*- //


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TR-4402

Issue: it is old issue with iPad for MathQuill lib https://github.com/mathquill/mathquill/issues?q=is%3Aissue+is%3Aopen+ipad
Lib is not supported since 2016 year
When second Japanese symbol is typed, no text in hidden textarea and no input event trigger.
So workaround is check all conditions - it is iPad, no input events, no text in input, it is visible key 
 

**How to test:**

1. create Delivery with Math PCI
2. open Delivery on iPad or simulator with Japanese keyboard
3. try to type more then 1 Japanese symbol
