### PR TITLE
fix: handle Backspace in Japanese IME

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mathquill",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mathquill",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "license": "MPL-2.0",
       "devDependencies": {
         "husky": "^7.0.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mathquill",
   "description": "Easily type math in your webapp",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "license": "MPL-2.0",
   "repository": {
     "type": "git",

--- a/src/services/saneKeyboardEvents.util.ts
+++ b/src/services/saneKeyboardEvents.util.ts
@@ -64,6 +64,7 @@ var saneKeyboardEvents = (function () {
     46: 'Del',
 
     144: 'NumLock',
+    229: 'Backspace', // Japanese IME on iPad
   };
 
   // To the extent possible, create a normalized string representation
@@ -89,12 +90,20 @@ var saneKeyboardEvents = (function () {
   function isVisibleKey(evt: JQ_KeyboardEvent) {
     var which = evt.which || evt.keyCode;
     var keyVal = KEY_VALUES[which];
-    return !(evt.ctrlKey || evt.originalEvent && evt.originalEvent.metaKey || evt.altKey || evt.shiftKey || keyVal);
+    return !(
+      evt.ctrlKey ||
+      (evt.originalEvent && evt.originalEvent.metaKey) ||
+      evt.altKey ||
+      evt.shiftKey ||
+      keyVal
+    );
   }
   function isIpadOS() {
-    return navigator.maxTouchPoints &&
+    return (
+      navigator.maxTouchPoints &&
       navigator.maxTouchPoints > 2 &&
-      /MacIntel/.test(navigator.platform);
+      /MacIntel/.test(navigator.platform)
+    );
   }
   // create a keyboard events shim that calls callbacks at useful times
   // and exports useful public methods
@@ -283,12 +292,20 @@ var saneKeyboardEvents = (function () {
         } else {
           controller.typedText(text);
         }
-      } else if (text.length === 0 && is_iPad && !input && keydown && keyup && !textWasInserted && isVisibleKey(keydown)) {
-          // issue with iPad and Japanese keyboard
-          // only first symbol put in textare,
-          // rest ignored and no text in textarea, no input event
-          // will be used keydown.key
-          controller.typedText(text);
+      } else if (
+        text.length === 0 &&
+        is_iPad &&
+        !input &&
+        keydown &&
+        keyup &&
+        !textWasInserted &&
+        isVisibleKey(keydown)
+      ) {
+        // issue with iPad and Japanese keyboard
+        // only first symbol put in textare,
+        // rest ignored and no text in textarea, no input event
+        // will be used keydown.key
+        controller.typedText(text);
       } // in Firefox, keys that don't type text, just clear seln, fire keypress
       // https://github.com/mathquill/mathquill/issues/293#issuecomment-40997668
       else if (text) guardedTextareaSelect(); // re-select if that's why we're here
@@ -369,7 +386,9 @@ var saneKeyboardEvents = (function () {
 
     // -*- attach event handlers -*- //
     textarea.bind({
-        input: function(e: JQ_InputEvent) { input = e; },
+      input: function (e: JQ_InputEvent) {
+        input = e;
+      },
     });
 
     // -*- export public methods -*- //

--- a/src/services/saneKeyboardEvents.util.ts
+++ b/src/services/saneKeyboardEvents.util.ts
@@ -64,8 +64,11 @@ var saneKeyboardEvents = (function () {
     46: 'Del',
 
     144: 'NumLock',
-    229: 'Backspace', // Japanese IME on iPad
   };
+
+  const SPECIAL_KEYS = Object.keys(KEY_VALUES).map(
+    (key: string) => KEY_VALUES[key as unknown as number]
+  );
 
   // To the extent possible, create a normalized string representation
   // of the key combo (i.e., key code and modifier keys).
@@ -74,6 +77,11 @@ var saneKeyboardEvents = (function () {
     var keyVal = KEY_VALUES[which];
     var key;
     var modifiers = [];
+    var originalEventKey = evt.originalEvent && evt.originalEvent.key;
+
+    if (!keyVal && SPECIAL_KEYS.indexOf(originalEventKey) !== -1) {
+      keyVal = originalEventKey;
+    }
 
     if (evt.ctrlKey) modifiers.push('Ctrl');
     if (evt.originalEvent && evt.originalEvent.metaKey) modifiers.push('Meta');
@@ -90,6 +98,10 @@ var saneKeyboardEvents = (function () {
   function isVisibleKey(evt: JQ_KeyboardEvent) {
     var which = evt.which || evt.keyCode;
     var keyVal = KEY_VALUES[which];
+    var originalEventKey = evt.originalEvent && evt.originalEvent.key;
+    if (!keyVal && SPECIAL_KEYS.indexOf(originalEventKey) !== -1) {
+      keyVal = originalEventKey;
+    }
     return !(
       evt.ctrlKey ||
       (evt.originalEvent && evt.originalEvent.metaKey) ||


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/INF-300

## What's Changed

Safari on iOS fires 229 key code for first two characters when using Japanese IME, which leads to an issue when Backspace is being treated as visible key.
To replicate this behaviour on macOS you can use the [Simulator](https://developer.apple.com/documentation/xcode/running-your-app-in-simulator-or-on-a-device).

## How to test

On macOS:
1. Open any iPad simulator via `File` → `Open simulator` and wait until virtual device boots up
2. Go to Settings → General → Keyboard → Keyboards
3. Search for Japanese keyboard and select Kana variant (important!)
4. Open Safari in simulator and go to https://tenant01-oat-dev.dev.gcp-eu.taocloud.org/deliveries
5. Search for `INF-300 Math Entry (Debug)` and click Preview
6. Use on-screen keyboard for inputs

On real device:
1. Go to Settings → General → Keyboard → Keyboards
2. Search for Japanese keyboard and select Kana variant (important!)
3. Open Safari and go to https://tenant01-oat-dev.dev.gcp-eu.taocloud.org/deliveries
4. Search for `INF-300 Math Entry (Debug)` and click Preview
5. Use on-screen keyboard for inputs

### How to reproduce the backspace bug

1. Input one character into the text field via Japanese IME
2. Try to erase it via backspace
3. See if other kana characters are working as well