### PR TITLE
Handle IME via sane keyboard util

### DIFF
--- a/src/services/saneKeyboardEvents.util.ts
+++ b/src/services/saneKeyboardEvents.util.ts
@@ -263,7 +263,12 @@ var saneKeyboardEvents = (function () {
     function syncCompositionText() {
       if (!isComposing) return;
       var text = textarea.val();
-      if (!text) return;
+      if (!text) {
+        if (compositionTextLength > 0) {
+          clearCompositionText();
+        }
+        return;
+      }
       if (text === compositionString) return;
       updateCompositionText(text);
     }
@@ -381,7 +386,13 @@ var saneKeyboardEvents = (function () {
         // only first symbol put in textare,
         // rest ignored and no text in textarea, no input event
         // will be used keydown.key
-        insertText(keydown.key || '');
+        var fallbackKey =
+          keydown.key ||
+          (keydown.originalEvent && keydown.originalEvent.key) ||
+          '';
+        if (fallbackKey.length === 1) {
+          insertText(fallbackKey);
+        }
       } // in Firefox, keys that don't type text, just clear seln, fire keypress
       // https://github.com/mathquill/mathquill/issues/293#issuecomment-40997668
       else if (text) {
@@ -421,6 +432,8 @@ var saneKeyboardEvents = (function () {
         } else if (text !== compositionString) {
           updateCompositionText(text);
         }
+      } else if (compositionTextLength > 0) {
+        clearCompositionText();
       }
 
       compositionTextLength = 0;

--- a/src/services/saneKeyboardEvents.util.ts
+++ b/src/services/saneKeyboardEvents.util.ts
@@ -125,7 +125,20 @@ var saneKeyboardEvents = (function () {
     var keyup: JQ_KeyboardEvent | null = null;
     var input: JQ_InputEvent | null = null;
     var textWasInserted = false;
+    var isComposing = false;
+    var compositionTextLength = 0;
+    var compositionString = '';
     var is_iPad = isIpadOS();
+
+    var LOG_PREFIX = '[Math Entry PCI | MathQuill]';
+    var noopKeyboardEvent = {
+      preventDefault: noop,
+    } as unknown as KeyboardEvent;
+    function debugIme(event: string, detail?: object) {
+      if (typeof console !== 'undefined' && console.debug) {
+        console.debug(LOG_PREFIX, event, detail || '');
+      }
+    }
 
     var textarea = jQuery(el);
     var target = jQuery(controller.container || textarea);
@@ -205,6 +218,94 @@ var saneKeyboardEvents = (function () {
       }
     }
 
+    function insertText(text: string) {
+      if (!text) return;
+
+      debugIme('insertText', { text: text, length: text.length });
+
+      if (controller.options && controller.options.overrideTypedText) {
+        for (var i = 0; i < text.length; i += 1) {
+          controller.options.overrideTypedText(text.charAt(i));
+        }
+      } else {
+        for (var j = 0; j < text.length; j += 1) {
+          controller.typedText(text.charAt(j));
+        }
+      }
+      textWasInserted = true;
+    }
+
+    function clearCompositionText() {
+      if (!compositionTextLength) return;
+
+      debugIme('clearCompositionText', {
+        backspaceCount: compositionTextLength,
+      });
+
+      for (var i = 0; i < compositionTextLength; i += 1) {
+        if (controller.options && controller.options.overrideKeystroke) {
+          controller.options.overrideKeystroke('Backspace', noopKeyboardEvent);
+        } else if (typeof controller.backspace === 'function') {
+          controller.backspace();
+        } else {
+          controller.keystroke('Backspace', noopKeyboardEvent);
+        }
+      }
+      compositionTextLength = 0;
+      compositionString = '';
+    }
+
+    function updateCompositionText(text: string) {
+      debugIme('updateCompositionText', {
+        text: text,
+        priorLength: compositionTextLength,
+      });
+      clearCompositionText();
+      if (!text) return;
+
+      if (controller.options && controller.options.overrideTypedText) {
+        for (var k = 0; k < text.length; k += 1) {
+          controller.options.overrideTypedText(text.charAt(k));
+        }
+      } else {
+        for (var l = 0; l < text.length; l += 1) {
+          controller.typedText(text.charAt(l));
+        }
+      }
+      compositionTextLength = text.length;
+      compositionString = text;
+      debugIme('updateCompositionText:done', {
+        compositionTextLength: compositionTextLength,
+      });
+    }
+
+    function syncCompositionText(source: string) {
+      if (!isComposing) return;
+      var text = textarea.val();
+      if (!text) {
+        debugIme(source, {
+          textareaVal: text,
+          compositionTextLength: compositionTextLength,
+          action: 'skip-empty',
+        });
+        return;
+      }
+      if (text === compositionString) {
+        debugIme(source, {
+          textareaVal: text,
+          compositionTextLength: compositionTextLength,
+          action: 'skip-unchanged',
+        });
+        return;
+      }
+      debugIme(source, {
+        textareaVal: text,
+        compositionTextLength: compositionTextLength,
+        action: 'sync',
+      });
+      updateCompositionText(text);
+    }
+
     // -*- event handlers -*- //
     function onKeydown(e: KeyboardEvent) {
       if (e.target !== textarea[0]) return;
@@ -223,6 +324,17 @@ var saneKeyboardEvents = (function () {
             guardedTextareaSelect();
           }
         });
+
+      if (isComposing || e.isComposing || e.keyCode === 229) {
+        debugIme('keydown', {
+          key: e.key,
+          keyCode: e.keyCode,
+          isComposing: isComposing,
+          eventIsComposing: e.isComposing,
+          action: 'skip-ime',
+        });
+        return;
+      }
 
       handleKey();
     }
@@ -258,6 +370,14 @@ var saneKeyboardEvents = (function () {
       // use the mq.keystroke('Right') command while a single character
       // is selected. Only detected in FF.
       if (!isArrowKey(e)) {
+        if (isComposing) {
+          debugIme('keypress', {
+            key: e.key,
+            keyCode: e.keyCode,
+            isComposing: isComposing,
+            action: 'schedule-typedText',
+          });
+        }
         checkTextareaFor(typedText);
       }
     }
@@ -272,6 +392,14 @@ var saneKeyboardEvents = (function () {
         // is selected. Only detected in FF.
         if (!isArrowKey(e)) {
           keyup = e;
+          if (isComposing) {
+            debugIme('keyup', {
+              key: e.key,
+              keyCode: e.keyCode,
+              isComposing: isComposing,
+              action: 'schedule-typedText',
+            });
+          }
           checkTextareaFor(typedText);
         }
       }
@@ -294,33 +422,129 @@ var saneKeyboardEvents = (function () {
       //   reliable as our tests are comprehensive
       // If anything like #40 or #71 is reported in IE < 9, see
       // b1318e5349160b665003e36d4eedd64101ceacd8
-      if (hasSelection()) return;
-
       var text = textarea.val();
+      if (hasSelection()) {
+        debugIme('typedText', {
+          textareaVal: text,
+          hasSelection: true,
+          isComposing: isComposing,
+          textWasInserted: textWasInserted,
+          action: 'skip',
+        });
+        return;
+      }
+      if (isComposing) {
+        debugIme('typedText', {
+          textareaVal: text,
+          isComposing: isComposing,
+          textWasInserted: textWasInserted,
+          action: 'skip',
+        });
+        return;
+      }
+      if (textWasInserted) {
+        debugIme('typedText', {
+          textareaVal: text,
+          isComposing: isComposing,
+          textWasInserted: textWasInserted,
+          action: 'skip',
+        });
+        return;
+      }
+
       if (text.length === 1) {
         textarea.val('');
-        if (controller.options && controller.options.overrideTypedText) {
-          controller.options.overrideTypedText(text);
-        } else {
-          controller.typedText(text);
-        }
+        debugIme('typedText', {
+          textareaVal: text,
+          isComposing: isComposing,
+          action: 'insertText',
+        });
+        insertText(text);
       } else if (
         text.length === 0 &&
         is_iPad &&
         !input &&
         keydown &&
         keyup &&
-        !textWasInserted &&
         isVisibleKey(keydown)
       ) {
         // issue with iPad and Japanese keyboard
         // only first symbol put in textare,
         // rest ignored and no text in textarea, no input event
         // will be used keydown.key
-        controller.typedText(text);
+        debugIme('typedText', {
+          textareaVal: text,
+          isComposing: isComposing,
+          key: keydown.key,
+          action: 'iPad-fallback',
+        });
+        insertText(keydown.key || '');
       } // in Firefox, keys that don't type text, just clear seln, fire keypress
       // https://github.com/mathquill/mathquill/issues/293#issuecomment-40997668
-      else if (text) guardedTextareaSelect(); // re-select if that's why we're here
+      else if (text) {
+        debugIme('typedText', {
+          textareaVal: text,
+          isComposing: isComposing,
+          action: 're-select',
+        });
+        guardedTextareaSelect(); // re-select if that's why we're here
+      }
+    }
+
+    function onCompositionStart() {
+      isComposing = true;
+      compositionTextLength = 0;
+      compositionString = '';
+      checkTextarea = noop;
+      clearTimeout(timeoutId);
+      debugIme('compositionstart', {
+        compositionTextLength: compositionTextLength,
+      });
+    }
+
+    function onCompositionUpdate() {
+      syncCompositionText('compositionupdate');
+    }
+
+    function onCompositionEnd(e?: JQ_InputEvent) {
+      var textareaVal = textarea.val();
+      var eventData =
+        e && e.originalEvent
+          ? (e.originalEvent as unknown as CompositionEvent).data
+          : undefined;
+      isComposing = false;
+      var text = textareaVal;
+      if (!text && eventData) {
+        text = eventData;
+      }
+      textarea.val('');
+
+      var priorCompositionLength = compositionTextLength;
+      var action = 'keep-interim';
+      if (text) {
+        if (compositionTextLength === 0) {
+          action = 'insertText';
+          insertText(text);
+          compositionString = text;
+        } else {
+          action = 'updateCompositionText';
+          updateCompositionText(text);
+        }
+      }
+
+      debugIme('compositionend', {
+        textareaVal: textareaVal,
+        eventData: eventData,
+        resolvedText: text,
+        compositionTextLength: priorCompositionLength,
+        action: action,
+      });
+
+      compositionTextLength = 0;
+      keydown = null;
+      keypress = null;
+      keyup = null;
+      input = null;
     }
 
     function onBlur() {
@@ -398,8 +622,14 @@ var saneKeyboardEvents = (function () {
 
     // -*- attach event handlers -*- //
     textarea.bind({
+      compositionstart: onCompositionStart,
+      compositionupdate: onCompositionUpdate,
+      compositionend: onCompositionEnd,
       input: function (e: JQ_InputEvent) {
         input = e;
+        if (isComposing) {
+          syncCompositionText('input-composing');
+        }
       },
     });
 

--- a/src/services/saneKeyboardEvents.util.ts
+++ b/src/services/saneKeyboardEvents.util.ts
@@ -418,7 +418,7 @@ var saneKeyboardEvents = (function () {
         if (compositionTextLength === 0) {
           insertText(text);
           compositionString = text;
-        } else {
+        } else if (text !== compositionString) {
           updateCompositionText(text);
         }
       }

--- a/src/services/saneKeyboardEvents.util.ts
+++ b/src/services/saneKeyboardEvents.util.ts
@@ -130,15 +130,9 @@ var saneKeyboardEvents = (function () {
     var compositionString = '';
     var is_iPad = isIpadOS();
 
-    var LOG_PREFIX = '[Math Entry PCI | MathQuill]';
     var noopKeyboardEvent = {
       preventDefault: noop,
     } as unknown as KeyboardEvent;
-    function debugIme(event: string, detail?: object) {
-      if (typeof console !== 'undefined' && console.debug) {
-        console.debug(LOG_PREFIX, event, detail || '');
-      }
-    }
 
     var textarea = jQuery(el);
     var target = jQuery(controller.container || textarea);
@@ -221,8 +215,6 @@ var saneKeyboardEvents = (function () {
     function insertText(text: string) {
       if (!text) return;
 
-      debugIme('insertText', { text: text, length: text.length });
-
       if (controller.options && controller.options.overrideTypedText) {
         for (var i = 0; i < text.length; i += 1) {
           controller.options.overrideTypedText(text.charAt(i));
@@ -238,10 +230,6 @@ var saneKeyboardEvents = (function () {
     function clearCompositionText() {
       if (!compositionTextLength) return;
 
-      debugIme('clearCompositionText', {
-        backspaceCount: compositionTextLength,
-      });
-
       for (var i = 0; i < compositionTextLength; i += 1) {
         if (controller.options && controller.options.overrideKeystroke) {
           controller.options.overrideKeystroke('Backspace', noopKeyboardEvent);
@@ -256,10 +244,6 @@ var saneKeyboardEvents = (function () {
     }
 
     function updateCompositionText(text: string) {
-      debugIme('updateCompositionText', {
-        text: text,
-        priorLength: compositionTextLength,
-      });
       clearCompositionText();
       if (!text) return;
 
@@ -274,35 +258,13 @@ var saneKeyboardEvents = (function () {
       }
       compositionTextLength = text.length;
       compositionString = text;
-      debugIme('updateCompositionText:done', {
-        compositionTextLength: compositionTextLength,
-      });
     }
 
-    function syncCompositionText(source: string) {
+    function syncCompositionText() {
       if (!isComposing) return;
       var text = textarea.val();
-      if (!text) {
-        debugIme(source, {
-          textareaVal: text,
-          compositionTextLength: compositionTextLength,
-          action: 'skip-empty',
-        });
-        return;
-      }
-      if (text === compositionString) {
-        debugIme(source, {
-          textareaVal: text,
-          compositionTextLength: compositionTextLength,
-          action: 'skip-unchanged',
-        });
-        return;
-      }
-      debugIme(source, {
-        textareaVal: text,
-        compositionTextLength: compositionTextLength,
-        action: 'sync',
-      });
+      if (!text) return;
+      if (text === compositionString) return;
       updateCompositionText(text);
     }
 
@@ -326,13 +288,6 @@ var saneKeyboardEvents = (function () {
         });
 
       if (isComposing || e.isComposing || e.keyCode === 229) {
-        debugIme('keydown', {
-          key: e.key,
-          keyCode: e.keyCode,
-          isComposing: isComposing,
-          eventIsComposing: e.isComposing,
-          action: 'skip-ime',
-        });
         return;
       }
 
@@ -370,14 +325,6 @@ var saneKeyboardEvents = (function () {
       // use the mq.keystroke('Right') command while a single character
       // is selected. Only detected in FF.
       if (!isArrowKey(e)) {
-        if (isComposing) {
-          debugIme('keypress', {
-            key: e.key,
-            keyCode: e.keyCode,
-            isComposing: isComposing,
-            action: 'schedule-typedText',
-          });
-        }
         checkTextareaFor(typedText);
       }
     }
@@ -392,14 +339,6 @@ var saneKeyboardEvents = (function () {
         // is selected. Only detected in FF.
         if (!isArrowKey(e)) {
           keyup = e;
-          if (isComposing) {
-            debugIme('keyup', {
-              key: e.key,
-              keyCode: e.keyCode,
-              isComposing: isComposing,
-              action: 'schedule-typedText',
-            });
-          }
           checkTextareaFor(typedText);
         }
       }
@@ -423,42 +362,12 @@ var saneKeyboardEvents = (function () {
       // If anything like #40 or #71 is reported in IE < 9, see
       // b1318e5349160b665003e36d4eedd64101ceacd8
       var text = textarea.val();
-      if (hasSelection()) {
-        debugIme('typedText', {
-          textareaVal: text,
-          hasSelection: true,
-          isComposing: isComposing,
-          textWasInserted: textWasInserted,
-          action: 'skip',
-        });
-        return;
-      }
-      if (isComposing) {
-        debugIme('typedText', {
-          textareaVal: text,
-          isComposing: isComposing,
-          textWasInserted: textWasInserted,
-          action: 'skip',
-        });
-        return;
-      }
-      if (textWasInserted) {
-        debugIme('typedText', {
-          textareaVal: text,
-          isComposing: isComposing,
-          textWasInserted: textWasInserted,
-          action: 'skip',
-        });
-        return;
-      }
+      if (hasSelection()) return;
+      if (isComposing) return;
+      if (textWasInserted) return;
 
       if (text.length === 1) {
         textarea.val('');
-        debugIme('typedText', {
-          textareaVal: text,
-          isComposing: isComposing,
-          action: 'insertText',
-        });
         insertText(text);
       } else if (
         text.length === 0 &&
@@ -472,21 +381,10 @@ var saneKeyboardEvents = (function () {
         // only first symbol put in textare,
         // rest ignored and no text in textarea, no input event
         // will be used keydown.key
-        debugIme('typedText', {
-          textareaVal: text,
-          isComposing: isComposing,
-          key: keydown.key,
-          action: 'iPad-fallback',
-        });
         insertText(keydown.key || '');
       } // in Firefox, keys that don't type text, just clear seln, fire keypress
       // https://github.com/mathquill/mathquill/issues/293#issuecomment-40997668
       else if (text) {
-        debugIme('typedText', {
-          textareaVal: text,
-          isComposing: isComposing,
-          action: 're-select',
-        });
         guardedTextareaSelect(); // re-select if that's why we're here
       }
     }
@@ -497,13 +395,10 @@ var saneKeyboardEvents = (function () {
       compositionString = '';
       checkTextarea = noop;
       clearTimeout(timeoutId);
-      debugIme('compositionstart', {
-        compositionTextLength: compositionTextLength,
-      });
     }
 
     function onCompositionUpdate() {
-      syncCompositionText('compositionupdate');
+      syncCompositionText();
     }
 
     function onCompositionEnd(e?: JQ_InputEvent) {
@@ -519,26 +414,14 @@ var saneKeyboardEvents = (function () {
       }
       textarea.val('');
 
-      var priorCompositionLength = compositionTextLength;
-      var action = 'keep-interim';
       if (text) {
         if (compositionTextLength === 0) {
-          action = 'insertText';
           insertText(text);
           compositionString = text;
         } else {
-          action = 'updateCompositionText';
           updateCompositionText(text);
         }
       }
-
-      debugIme('compositionend', {
-        textareaVal: textareaVal,
-        eventData: eventData,
-        resolvedText: text,
-        compositionTextLength: priorCompositionLength,
-        action: action,
-      });
 
       compositionTextLength = 0;
       keydown = null;
@@ -628,7 +511,7 @@ var saneKeyboardEvents = (function () {
       input: function (e: JQ_InputEvent) {
         input = e;
         if (isComposing) {
-          syncCompositionText('input-composing');
+          syncCompositionText();
         }
       },
     });

--- a/test/support/assert.js
+++ b/test/support/assert.js
@@ -35,6 +35,19 @@ window.assert = (function () {
         explanation: 'expected (' + thing1 + ') to equal (' + thing2 + ')',
       });
     },
+    deepEqual: function (thing1, thing2, message) {
+      if (JSON.stringify(thing1) === JSON.stringify(thing2)) return;
+
+      fail({
+        message: message,
+        explanation:
+          'expected (' +
+          JSON.stringify(thing1) +
+          ') to deepEqual (' +
+          JSON.stringify(thing2) +
+          ')',
+      });
+    },
     throws: function (fn, message) {
       var error = false;
 

--- a/test/unit/saneKeyboardEvents.test.js
+++ b/test/unit/saneKeyboardEvents.test.js
@@ -625,7 +625,7 @@ suite('saneKeyboardEvents', function () {
       el.val('かな');
       el.trigger('compositionupdate');
       assert.equal(counter, 3, 'updated kana shown during composition');
-      assert.deepEqual(typed, ['か', 'な']);
+      assert.deepEqual(typed, ['か', 'か', 'な']);
       el.val('かな');
       el.trigger('compositionend');
       assert.equal(counter, 3, 'no duplicate insert on composition end');
@@ -715,7 +715,7 @@ suite('saneKeyboardEvents', function () {
       el.val('かな');
       el.trigger('compositionupdate');
       assert.equal(backspaceCount, 1, 'one backspace when growing composition');
-      assert.deepEqual(typed, ['か', 'な']);
+      assert.deepEqual(typed, ['か', 'か', 'な']);
     });
     test('skips unchanged compositionupdate', function () {
       var typed = [];

--- a/test/unit/saneKeyboardEvents.test.js
+++ b/test/unit/saneKeyboardEvents.test.js
@@ -506,4 +506,237 @@ suite('saneKeyboardEvents', function () {
       el.trigger('copy');
     });
   });
+
+  suite('iPad Japanese IME', function () {
+    var origMaxTouchPoints;
+    var origPlatform;
+    setup(function () {
+      origMaxTouchPoints = navigator.maxTouchPoints;
+      origPlatform = navigator.platform;
+      Object.defineProperty(navigator, 'maxTouchPoints', {
+        value: 5,
+        configurable: true,
+      });
+      Object.defineProperty(navigator, 'platform', {
+        value: 'MacIntel',
+        configurable: true,
+      });
+    });
+    teardown(function () {
+      Object.defineProperty(navigator, 'maxTouchPoints', {
+        value: origMaxTouchPoints,
+        configurable: true,
+      });
+      Object.defineProperty(navigator, 'platform', {
+        value: origPlatform,
+        configurable: true,
+      });
+    });
+    test('inserts each kana once via keydown.key fallback', function (done) {
+      var counter = 0;
+      var typed = [];
+      saneKeyboardEvents(el, {
+        keystroke: noop,
+        typedText: function (text) {
+          counter += 1;
+          typed.push(text);
+        },
+      });
+      el.trigger(
+        Event('keydown', {
+          key: 'る',
+          which: 0,
+          originalEvent: { key: 'る' },
+        })
+      );
+      el.trigger(
+        Event('keyup', {
+          key: 'る',
+          which: 0,
+          originalEvent: { key: 'る' },
+        })
+      );
+      setTimeout(function () {
+        assert.equal(counter, 1, 'first kana inserted once');
+        assert.deepEqual(typed, ['る']);
+        counter = 0;
+        typed = [];
+        el.trigger(
+          Event('keydown', {
+            key: 'れ',
+            which: 0,
+            originalEvent: { key: 'れ' },
+          })
+        );
+        el.trigger(
+          Event('keyup', {
+            key: 'れ',
+            which: 0,
+            originalEvent: { key: 'れ' },
+          })
+        );
+        setTimeout(function () {
+          assert.equal(counter, 1, 'second kana inserted once');
+          assert.deepEqual(typed, ['れ']);
+          done();
+        }, 0);
+      }, 0);
+    });
+  });
+
+  suite('IME composition', function () {
+    test('suppresses interim Latin chars and commits on compositionend', function () {
+      var counter = 0;
+      var typed = [];
+      saneKeyboardEvents(el, {
+        keystroke: noop,
+        typedText: function (text) {
+          counter += 1;
+          typed.push(text);
+        },
+      });
+      el.trigger('compositionstart');
+      el.val('h');
+      el.trigger(Event('keydown', { which: 104 }));
+      el.trigger(Event('keypress', { which: 104 }));
+      el.trigger('input');
+      assert.equal(counter, 0, 'no insert during composition');
+      el.val('ひ');
+      el.trigger('compositionend');
+      assert.equal(counter, 1, 'single insert on composition end');
+      assert.equal(typed.join(''), 'ひ');
+      assert.equal(el.val(), '', 'textarea cleared after commit');
+    });
+    test('shows interim Japanese text during compositionupdate', function () {
+      var counter = 0;
+      var typed = [];
+      saneKeyboardEvents(el, {
+        keystroke: noop,
+        typedText: function (text) {
+          counter += 1;
+          typed.push(text);
+        },
+      });
+      el.trigger('compositionstart');
+      el.val('か');
+      el.trigger('compositionupdate');
+      assert.equal(counter, 1, 'first kana shown during composition');
+      assert.deepEqual(typed, ['か']);
+      el.val('かな');
+      el.trigger('compositionupdate');
+      assert.equal(counter, 3, 'updated kana shown during composition');
+      assert.deepEqual(typed, ['か', 'な']);
+      el.val('かな');
+      el.trigger('compositionend');
+      assert.equal(counter, 3, 'no duplicate insert on composition end');
+      assert.equal(el.val(), '', 'textarea cleared after commit');
+    });
+    test('keeps interim text when compositionend has empty textarea', function () {
+      var counter = 0;
+      var typed = [];
+      saneKeyboardEvents(el, {
+        keystroke: noop,
+        typedText: function (text) {
+          counter += 1;
+          typed.push(text);
+        },
+      });
+      el.trigger('compositionstart');
+      el.val('ひ');
+      el.trigger('compositionupdate');
+      assert.equal(counter, 1, 'interim kana shown during composition');
+      assert.deepEqual(typed, ['ひ']);
+      el.val('');
+      el.trigger('compositionend');
+      assert.equal(counter, 1, 'should not erase on empty compositionend');
+      assert.deepEqual(typed, ['ひ']);
+      assert.equal(el.val(), '', 'textarea cleared after commit');
+    });
+    test('does not erase interim text on empty compositionupdate', function () {
+      var counter = 0;
+      var typed = [];
+      saneKeyboardEvents(el, {
+        keystroke: noop,
+        typedText: function (text) {
+          counter += 1;
+          typed.push(text);
+        },
+      });
+      el.trigger('compositionstart');
+      el.val('ひ');
+      el.trigger('compositionupdate');
+      assert.equal(counter, 1, 'interim kana shown during composition');
+      assert.deepEqual(typed, ['ひ']);
+      el.val('');
+      el.trigger('compositionupdate');
+      assert.equal(counter, 1, 'should not erase on empty compositionupdate');
+      assert.deepEqual(typed, ['ひ']);
+    });
+    test('does not erase interim text on empty input while composing', function () {
+      var counter = 0;
+      var typed = [];
+      saneKeyboardEvents(el, {
+        keystroke: noop,
+        typedText: function (text) {
+          counter += 1;
+          typed.push(text);
+        },
+      });
+      el.trigger('compositionstart');
+      el.val('ひ');
+      el.trigger('compositionupdate');
+      assert.equal(counter, 1, 'interim kana shown during composition');
+      assert.deepEqual(typed, ['ひ']);
+      el.val('');
+      el.trigger('input');
+      assert.equal(
+        counter,
+        1,
+        'should not erase on empty input while composing'
+      );
+      assert.deepEqual(typed, ['ひ']);
+    });
+    test('updates growing composition without throwing', function () {
+      var typed = [];
+      var backspaceCount = 0;
+      saneKeyboardEvents(el, {
+        keystroke: noop,
+        backspace: function () {
+          backspaceCount += 1;
+        },
+        typedText: function (text) {
+          typed.push(text);
+        },
+      });
+      el.trigger('compositionstart');
+      el.val('か');
+      el.trigger('compositionupdate');
+      assert.deepEqual(typed, ['か']);
+      el.val('かな');
+      el.trigger('compositionupdate');
+      assert.equal(backspaceCount, 1, 'one backspace when growing composition');
+      assert.deepEqual(typed, ['か', 'な']);
+    });
+    test('skips unchanged compositionupdate', function () {
+      var typed = [];
+      var backspaceCount = 0;
+      saneKeyboardEvents(el, {
+        keystroke: noop,
+        backspace: function () {
+          backspaceCount += 1;
+        },
+        typedText: function (text) {
+          typed.push(text);
+        },
+      });
+      el.trigger('compositionstart');
+      el.val('ひ');
+      el.trigger('compositionupdate');
+      assert.deepEqual(typed, ['ひ']);
+      el.val('ひ');
+      el.trigger('compositionupdate');
+      assert.equal(backspaceCount, 0, 'no backspace on unchanged composition');
+      assert.deepEqual(typed, ['ひ']);
+    });
+  });
 });


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/INF-543

## What's Changed

- Added Japanese IME composition handling to saneKeyboardEvents (compositionstart / compositionupdate / compositionend, composing input).
- Suppressed romaji leakage during IME by skipping keydown / typedText while composing (isComposing, keyCode === 229).
- Synced interim kana into MathQuill via updateCompositionText / syncCompositionText, with guards for:
- empty textarea (skip-empty)
- unchanged composition string (skip-unchanged)
- empty compositionend when interim text is already shown
- Fixed programmatic composition clear to use controller.backspace() (with noop keyboard-event fallback) instead of keystroke('Backspace', null), which crashed on e.preventDefault().
- Kept iPad Japanese IME fallback via keydown.key when the textarea stays empty.
- Added temporary console.debug diagnostics prefixed with [Math Entry PCI | MathQuill] for delivery troubleshooting.
- Extended unit tests for IME composition, iPad fallback, growing composition, and regression cases.

## TODO 

- [x] Unit tests

## How to test

1. Build mathquill: `make`
2. Run unit tests: `make test`
3. Open test/unit.html and confirm the saneKeyboardEvents IME suites pass.
4. Integrate into Math Entry PCI:
    - Copy build/mathquill.js into extension-tao-itemqti-pci/.../runtime/mathquill/mathquill.js
    - Rebuild PCI (grunt portableelement -e=qtiItemPci -i=mathEntryInteraction) and upload the PCI zip to any environment.
5. Manual IME check (macOS / iPad, Japanese input):
    - Open a Math Entry item in test delivery
    - Type hiragana (e.g. わをんー) - interim kana should update live, no romaji leakage, no erase after first character
    - Type English math (e.g. x+1) — should still work
    - Optional debug: in browser DevTools, enable Verbose and filter console by Math Entry PCI to inspect composition event flow (sync, skip-empty, skip-unchanged, no preventDefault errors).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added improved IME composition tracking with real-time synchronization of interim text (including Japanese IME).
  * Enhanced composition lifecycle handling: typing is suppressed during composition and committed text is applied on completion.
* **Bug Fixes**
  * Prevented duplicate kana insertion on iPad/Japanese IME flows.
  * Avoided unintended clearing of interim composition text and refined backspacing behavior during updates.
* **Tests**
  * Added extensive IME and iPad/Japanese IME coverage (start/update/end, empty event edge cases, sync behavior).
  * Added a `deepEqual` test assertion helper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->