### PR TITLE
fix: preserve fractions during Japanese IME input

### DIFF
--- a/src/services/saneKeyboardEvents.util.ts
+++ b/src/services/saneKeyboardEvents.util.ts
@@ -231,6 +231,9 @@ var saneKeyboardEvents = (function () {
       if (!compositionTextLength) return;
 
       for (var i = 0; i < compositionTextLength; i += 1) {
+        if (!controller.cursor[L]) {
+          break;
+        }
         if (controller.options && controller.options.overrideKeystroke) {
           controller.options.overrideKeystroke('Backspace', noopKeyboardEvent);
         } else if (typeof controller.backspace === 'function') {
@@ -244,18 +247,17 @@ var saneKeyboardEvents = (function () {
     }
 
     function updateCompositionText(text: string) {
-      clearCompositionText();
+      if (text.indexOf(compositionString) === 0) {
+        insertText(text.slice(compositionString.length));
+      } else if (compositionString.indexOf(text) === 0) {
+        compositionTextLength = compositionString.length - text.length;
+        clearCompositionText();
+      } else {
+        clearCompositionText();
+        insertText(text);
+      }
       if (!text) return;
 
-      if (controller.options && controller.options.overrideTypedText) {
-        for (var k = 0; k < text.length; k += 1) {
-          controller.options.overrideTypedText(text.charAt(k));
-        }
-      } else {
-        for (var l = 0; l < text.length; l += 1) {
-          controller.typedText(text.charAt(l));
-        }
-      }
       compositionTextLength = text.length;
       compositionString = text;
     }
@@ -437,6 +439,7 @@ var saneKeyboardEvents = (function () {
       }
 
       compositionTextLength = 0;
+      compositionString = '';
       keydown = null;
       keypress = null;
       keyup = null;
@@ -446,6 +449,12 @@ var saneKeyboardEvents = (function () {
     function onBlur() {
       keydown = null;
       keypress = null;
+      keyup = null;
+      input = null;
+      textWasInserted = false;
+      isComposing = false;
+      compositionTextLength = 0;
+      compositionString = '';
       checkTextarea = noop;
       clearTimeout(timeoutId);
       textarea.val('');

--- a/test/unit/saneKeyboardEvents.test.js
+++ b/test/unit/saneKeyboardEvents.test.js
@@ -624,11 +624,11 @@ suite('saneKeyboardEvents', function () {
       assert.deepEqual(typed, ['か']);
       el.val('かな');
       el.trigger('compositionupdate');
-      assert.equal(counter, 3, 'updated kana shown during composition');
-      assert.deepEqual(typed, ['か', 'か', 'な']);
+      assert.equal(counter, 2, 'only new kana shown during composition');
+      assert.deepEqual(typed, ['か', 'な']);
       el.val('かな');
       el.trigger('compositionend');
-      assert.equal(counter, 3, 'no duplicate insert on composition end');
+      assert.equal(counter, 2, 'no duplicate insert on composition end');
       assert.equal(el.val(), '', 'textarea cleared after commit');
     });
     test('keeps interim text when compositionend has empty textarea', function () {
@@ -636,6 +636,7 @@ suite('saneKeyboardEvents', function () {
       var typed = [];
       saneKeyboardEvents(el, {
         keystroke: noop,
+        cursor: {},
         typedText: function (text) {
           counter += 1;
           typed.push(text);
@@ -657,6 +658,7 @@ suite('saneKeyboardEvents', function () {
       var typed = [];
       saneKeyboardEvents(el, {
         keystroke: noop,
+        cursor: {},
         typedText: function (text) {
           counter += 1;
           typed.push(text);
@@ -677,6 +679,7 @@ suite('saneKeyboardEvents', function () {
       var typed = [];
       saneKeyboardEvents(el, {
         keystroke: noop,
+        cursor: {},
         typedText: function (text) {
           counter += 1;
           typed.push(text);
@@ -696,11 +699,12 @@ suite('saneKeyboardEvents', function () {
       );
       assert.deepEqual(typed, ['ひ']);
     });
-    test('updates growing composition without throwing', function () {
+    test('inserts only new text when composition grows', function () {
       var typed = [];
       var backspaceCount = 0;
       saneKeyboardEvents(el, {
         keystroke: noop,
+        cursor: {},
         backspace: function () {
           backspaceCount += 1;
         },
@@ -714,8 +718,78 @@ suite('saneKeyboardEvents', function () {
       assert.deepEqual(typed, ['か']);
       el.val('かな');
       el.trigger('compositionupdate');
-      assert.equal(backspaceCount, 1, 'one backspace when growing composition');
-      assert.deepEqual(typed, ['か', 'か', 'な']);
+      assert.equal(backspaceCount, 0, 'no backspace when growing composition');
+      assert.deepEqual(typed, ['か', 'な']);
+    });
+    test('deletes only removed text when composition shrinks', function () {
+      var typed = [];
+      var backspaceCount = 0;
+      var controller = {
+        keystroke: noop,
+        cursor: {},
+        backspace: function () {
+          backspaceCount += 1;
+        },
+        typedText: function (text) {
+          typed.push(text);
+        },
+      };
+      controller.cursor[L] = {};
+      saneKeyboardEvents(el, controller);
+      el.trigger('compositionstart');
+      el.val('1234');
+      el.trigger('compositionupdate');
+      assert.deepEqual(typed, ['1', '2', '3', '4']);
+      el.val('123');
+      el.trigger('compositionupdate');
+      assert.equal(backspaceCount, 1, 'one backspace for removed digit');
+      assert.deepEqual(typed, ['1', '2', '3', '4']);
+    });
+    test('does not delete outside current math block', function () {
+      var typed = [];
+      var backspaceCount = 0;
+      saneKeyboardEvents(el, {
+        keystroke: noop,
+        cursor: {},
+        backspace: function () {
+          backspaceCount += 1;
+        },
+        typedText: function (text) {
+          typed.push(text);
+        },
+      });
+      el.trigger('compositionstart');
+      el.val('12');
+      el.trigger('compositionupdate');
+      el.val('x');
+      el.trigger('compositionupdate');
+      assert.equal(backspaceCount, 0, 'backspace stops at block boundary');
+      assert.deepEqual(typed, ['1', '2', 'x']);
+    });
+    test('clears composition state on blur', function () {
+      var typed = [];
+      var backspaceCount = 0;
+      var controller = {
+        keystroke: noop,
+        cursor: {},
+        backspace: function () {
+          backspaceCount += 1;
+        },
+        typedText: function (text) {
+          typed.push(text);
+        },
+      };
+      controller.cursor[L] = {};
+      saneKeyboardEvents(el, controller);
+      el.trigger('compositionstart');
+      el.val('1234');
+      el.trigger('compositionupdate');
+      el.trigger('blur');
+      el.trigger('compositionstart');
+      el.val('123');
+      el.trigger('compositionupdate');
+      assert.equal(backspaceCount, 0, 'stale text is not deleted after blur');
+      assert.deepEqual(typed, ['1', '2', '3', '4', '1', '2', '3']);
     });
     test('skips unchanged compositionupdate', function () {
       var typed = [];

--- a/test/unit/saneKeyboardEvents.test.js
+++ b/test/unit/saneKeyboardEvents.test.js
@@ -631,17 +631,23 @@ suite('saneKeyboardEvents', function () {
       assert.equal(counter, 2, 'no duplicate insert on composition end');
       assert.equal(el.val(), '', 'textarea cleared after commit');
     });
-    test('keeps interim text when compositionend has empty textarea', function () {
+    test('clears interim text when compositionend has empty textarea', function () {
       var counter = 0;
       var typed = [];
-      saneKeyboardEvents(el, {
+      var backspaceCount = 0;
+      var controller = {
         keystroke: noop,
         cursor: {},
+        backspace: function () {
+          backspaceCount += 1;
+        },
         typedText: function (text) {
           counter += 1;
           typed.push(text);
         },
-      });
+      };
+      controller.cursor[L] = {};
+      saneKeyboardEvents(el, controller);
       el.trigger('compositionstart');
       el.val('ひ');
       el.trigger('compositionupdate');
@@ -649,21 +655,28 @@ suite('saneKeyboardEvents', function () {
       assert.deepEqual(typed, ['ひ']);
       el.val('');
       el.trigger('compositionend');
-      assert.equal(counter, 1, 'should not erase on empty compositionend');
+      assert.equal(backspaceCount, 1, 'interim text cleared once');
+      assert.equal(counter, 1, 'empty compositionend inserts no text');
       assert.deepEqual(typed, ['ひ']);
       assert.equal(el.val(), '', 'textarea cleared after commit');
     });
-    test('does not erase interim text on empty compositionupdate', function () {
+    test('clears interim text on empty compositionupdate', function () {
       var counter = 0;
       var typed = [];
-      saneKeyboardEvents(el, {
+      var backspaceCount = 0;
+      var controller = {
         keystroke: noop,
         cursor: {},
+        backspace: function () {
+          backspaceCount += 1;
+        },
         typedText: function (text) {
           counter += 1;
           typed.push(text);
         },
-      });
+      };
+      controller.cursor[L] = {};
+      saneKeyboardEvents(el, controller);
       el.trigger('compositionstart');
       el.val('ひ');
       el.trigger('compositionupdate');
@@ -671,20 +684,27 @@ suite('saneKeyboardEvents', function () {
       assert.deepEqual(typed, ['ひ']);
       el.val('');
       el.trigger('compositionupdate');
-      assert.equal(counter, 1, 'should not erase on empty compositionupdate');
+      assert.equal(backspaceCount, 1, 'interim text cleared once');
+      assert.equal(counter, 1, 'empty compositionupdate inserts no text');
       assert.deepEqual(typed, ['ひ']);
     });
-    test('does not erase interim text on empty input while composing', function () {
+    test('clears interim text on empty input while composing', function () {
       var counter = 0;
       var typed = [];
-      saneKeyboardEvents(el, {
+      var backspaceCount = 0;
+      var controller = {
         keystroke: noop,
         cursor: {},
+        backspace: function () {
+          backspaceCount += 1;
+        },
         typedText: function (text) {
           counter += 1;
           typed.push(text);
         },
-      });
+      };
+      controller.cursor[L] = {};
+      saneKeyboardEvents(el, controller);
       el.trigger('compositionstart');
       el.val('ひ');
       el.trigger('compositionupdate');
@@ -692,11 +712,8 @@ suite('saneKeyboardEvents', function () {
       assert.deepEqual(typed, ['ひ']);
       el.val('');
       el.trigger('input');
-      assert.equal(
-        counter,
-        1,
-        'should not erase on empty input while composing'
-      );
+      assert.equal(backspaceCount, 1, 'interim text cleared once');
+      assert.equal(counter, 1, 'empty input inserts no text while composing');
       assert.deepEqual(typed, ['ひ']);
     });
     test('inserts only new text when composition grows', function () {


### PR DESCRIPTION
Related to: [INF-552](https://oat-sa.atlassian.net/browse/INF-552)


Include changes from https://github.com/oat-sa/extension-tao-itemqti-pci/pull/522

[INF-552]: https://oat-sa.atlassian.net/browse/INF-552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IME/composition updates to handle incremental growth and shrink more accurately.
  * Prevented duplicate characters from appearing during Japanese text composition.
  * Strengthened composition cleanup on blur/focus changes to avoid stale text after refocusing.
  * Made backspace/deletion behavior cursor-aware so edits only affect the active area.
* **Tests**
  * Updated and expanded IME composition event tests to match the revised composition-diff behavior and cursor-scoped handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->